### PR TITLE
Instantiating lxc class instead of calling container method

### DIFF
--- a/bin/check-lxc-memstat.rb
+++ b/bin/check-lxc-memstat.rb
@@ -49,7 +49,7 @@ class CheckLXCMemstat < Sensu::Plugin::Check::CLI
 
   def run
     lxc = LXC.new
-    conn = LXC::Container.new(:lxc => lxc, :name => "#{config[:name]}")
+    conn = LXC::Container.new(lxc: lxc, name: "#{config[:name]}")
     if conn.exists?
       if conn.running?
         used = conn.memory_usage

--- a/bin/check-lxc-memstat.rb
+++ b/bin/check-lxc-memstat.rb
@@ -48,7 +48,8 @@ class CheckLXCMemstat < Sensu::Plugin::Check::CLI
          default: '90'
 
   def run
-    conn = LXC.container("#{config[:name]}")
+    lxc = LXC.new
+    conn = LXC::Container.new(:lxc => lxc, :name => "#{config[:name]}")
     if conn.exists?
       if conn.running?
         used = conn.memory_usage

--- a/bin/check-lxc-status.rb
+++ b/bin/check-lxc-status.rb
@@ -38,7 +38,8 @@ class CheckLXCSTATUS < Sensu::Plugin::Check::CLI
          default: 'testdebian'
 
   def run
-    conn = LXC.container("#{config[:name]}")
+    lxc = LXC.new
+    conn = LXC::Container.new(:lxc => lxc, :name => "#{config[:name]}")
     if conn.exists?
       if conn.stopped?
         critical "container #{config[:name]} is Stopped"

--- a/bin/check-lxc-status.rb
+++ b/bin/check-lxc-status.rb
@@ -39,7 +39,7 @@ class CheckLXCSTATUS < Sensu::Plugin::Check::CLI
 
   def run
     lxc = LXC.new
-    conn = LXC::Container.new(:lxc => lxc, :name => "#{config[:name]}")
+    conn = LXC::Container.new(lxc: lxc, name: "#{config[:name]}")
     if conn.exists?
       if conn.stopped?
         critical "container #{config[:name]} is Stopped"


### PR DESCRIPTION
This resolves the missing method error for ruby 2.0
