### PR TITLE
Fixing method call to LXC rubygem.

### DIFF
--- a/bin/check-lxc-memstat.rb
+++ b/bin/check-lxc-memstat.rb
@@ -49,7 +49,7 @@ class CheckLXCMemstat < Sensu::Plugin::Check::CLI
 
   def run
     lxc = LXC.new
-    conn = LXC.container.new(lxc: lxc, name: config[:name].to_s)
+    conn = LXC::Container.new(lxc: lxc, name: config[:name].to_s)
     if conn.exists?
       if conn.running?
         used = conn.memory_usage

--- a/bin/check-lxc-status.rb
+++ b/bin/check-lxc-status.rb
@@ -39,7 +39,7 @@ class CheckLXCSTATUS < Sensu::Plugin::Check::CLI
 
   def run
     lxc = LXC.new
-    conn = LXC.container.new(lxc: lxc, name: config[:name].to_s)
+    conn = LXC::Container.new(lxc: lxc, name: config[:name].to_s)
     if conn.exists?
       if conn.stopped?
         critical "container #{config[:name]} is Stopped"


### PR DESCRIPTION
The call to LXC module was incorrect and throwing an error.  See http://zpatten.github.io/lxc/
